### PR TITLE
Bugfix - Noisy warning logs during authentication when SAML is enabled

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -75,6 +75,8 @@ data:
         </encoder>
       </appender>
       <logger name="net.liftweb" level="WARN" />
+      <logger name="org.pac4j.saml" level="WARN" />
+      <logger name="org.apache.velocity" level="ERROR" />
       <root level="INFO">
         <appender-ref ref="logFile" />
         <appender-ref ref="stdout" />


### PR DESCRIPTION
CDX-3355

---

Pac4j, the library used for SAML in SRM, manually configures a deprecated Velocity property in an internal utility, causing a warning log during SAML auth.

The latest version of pac4j still configures the deprecated properties: https://github.com/pac4j/pac4j/blob/master/pac4j-saml/src/main/java/org/pac4j/saml/util/VelocityEngineFactory.java#L31

Pac4j configures the new and old versions of the property, so we shouldn't be affected if/when the deprecated property is removed, and the warning log is not relevant to us.

Similarly, the pac4j `DefaultSignatureSigningParametersProvider` logs basic information whenever it is invoked as part of SAML auth, which is also not relevant to us.

The log filter has been updated to exclude these log messages.