### PR TITLE
feat: add 'extraEnv', 'extraVolumes', 'extraVolumeMounts' fields

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
               value: "admin"
             - name: SRM_WEBAPP_NAME
               value: "{{ include "srm-web.appName" . }}"
+          {{- with .Values.web.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.web.image.registry }}/{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           readinessProbe:
@@ -179,6 +182,9 @@ spec:
               mountPath: {{ include "srm-web.database.pubkey.path" . }}
               subPath: {{ include "srm-web.database.pubkey.filename" . }}
             {{- end }}
+          {{- with .Values.web.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       initContainers:
         - name: srm-dbinit
           securityContext:
@@ -334,3 +340,6 @@ spec:
             - key: {{ include "srm-web.database.pubkey.filename" . }}
               path: {{ include "srm-web.database.pubkey.filename" . }}
         {{- end }}
+      {{- with .Values.web.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -293,6 +293,15 @@ web:
   # -- the pod tolerations for the web component
   tolerations: []
 
+  # -- extra environment variables to add to the srm-web container
+  extraEnv: []
+
+  # -- extra volume mounts to add to the srm-web container
+  extraVolumeMounts: []
+
+  # -- extra volumes to add to the srm-web pod
+  extraVolumes: []
+
   # -- the K8s secret name containing the API key for the Tool Orchestration tool service with required field to-key.props that
   # contains a HOCON-formatted file with SRM prop tws.api-key
   # File:


### PR DESCRIPTION
This PR adds some simple pass-through fields to customize the `env`, `volumes`, and `volumeMounts` definitions in the SRM webapp deployment.

This will be needed to support Google Workload Identity Federation - it involves mounting a service account token and mounting from a user-defined configmap: https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#deploy