### PR TITLE
Update/minio migration from bitnami to official

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,6 +20,6 @@ dependencies:
   repository: https://argoproj.github.io/argo-helm
   condition: features.to
 - name: minio
-  version: 3.5.0
-  repository: https://codedx.github.io/srm-k8s
+  version: 5.4.0
+  repository: https://charts.min.io/
   condition: features.minio

--- a/chart/templates/_secrets.tpl
+++ b/chart/templates/_secrets.tpl
@@ -32,18 +32,14 @@ Returns the MariaDB credential secret name (overwrites template).
 {{- end -}}
 
 {{/*
-Returns the MinIO secret name used by the official MinIO chart sub-chart.
-The official MinIO chart (charts.min.io) reads credentials from the secret
-named by minio.existingSecret, expecting keys rootUser and rootPassword.
-The SRM-generated secret (to-default-storage-secret.yaml) stores the same
-credential under access-key / secret-key so that the tool service can mount
-them without change.  We therefore create the secret with BOTH sets of keys.
+Returns the MinIO secret name used by the SRM chart templates (tool service
+volume mounts, network policies, etc.).
 */}}
 {{- define "minio.ref.secretName" -}}
 {{- if (not .Values.minio.existingSecret) -}}
 {{ include "srm-to.default.minio.secret" . }}
 {{- else -}}
-{{ required "You must specify a value for the 'minio.existingSecret' helm property" .Values.minio.existingSecret }}
+{{ .Values.minio.existingSecret }}
 {{- end -}}
 {{- end -}}
 

--- a/chart/templates/_secrets.tpl
+++ b/chart/templates/_secrets.tpl
@@ -32,48 +32,18 @@ Returns the MariaDB credential secret name (overwrites template).
 {{- end -}}
 
 {{/*
-Returns the MinIO secret name (overwrites template).
-*/}}
-{{- define "minio.secretName" -}}
-{{- if (not .Values.global.minio.existingSecret) -}}
-{{ include "srm-to.default.minio.secret" . }}
-{{- else -}}
-{{ required "You must specify a value for the 'global.minio.existingSecret' helm property" .Values.global.minio.existingSecret }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Get the root user key by switching the default from root-user to access-key (overwrites template).
-*/}}
-{{- define "minio.rootUserKey" -}}
-{{- if and (.Values.auth.existingSecret) (.Values.auth.rootUserSecretKey) -}}
-    {{- printf "%s" (tpl .Values.auth.rootUserSecretKey $) -}}
-{{- else -}}
-    {{/* Use the legacy name for key instead of root-user. */}}
-    {{- "access-key" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Get the root password key by switching the default from root-password to secret-key (overwrites template).
-*/}}
-{{- define "minio.rootPasswordKey" -}}
-{{- if and (.Values.auth.existingSecret) (.Values.auth.rootPasswordSecretKey) -}}
-    {{- printf "%s" (tpl .Values.auth.rootPasswordSecretKey $) -}}
-{{- else -}}
-    {{/* Use the legacy name for password instead of root-password. */}}
-    {{- "secret-key" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Returns the MinIO secret name.
+Returns the MinIO secret name used by the official MinIO chart sub-chart.
+The official MinIO chart (charts.min.io) reads credentials from the secret
+named by minio.existingSecret, expecting keys rootUser and rootPassword.
+The SRM-generated secret (to-default-storage-secret.yaml) stores the same
+credential under access-key / secret-key so that the tool service can mount
+them without change.  We therefore create the secret with BOTH sets of keys.
 */}}
 {{- define "minio.ref.secretName" -}}
-{{- if (not .Values.minio.global.minio.existingSecret) -}}
+{{- if (not .Values.minio.existingSecret) -}}
 {{ include "srm-to.default.minio.secret" . }}
 {{- else -}}
-{{ required "You must specify a value for the 'minio.global.minio.existingSecret' helm property" .Values.minio.global.minio.existingSecret }}
+{{ required "You must specify a value for the 'minio.existingSecret' helm property" .Values.minio.existingSecret }}
 {{- end -}}
 {{- end -}}
 

--- a/chart/templates/_subchart.tpl
+++ b/chart/templates/_subchart.tpl
@@ -4,8 +4,20 @@ so the Bitnami template-override helpers (minio.createSecret,
 minio.secret.userValue, minio.secret.passwordValue, common.errors.insecureImages)
 are no longer needed and have been removed.
 
-Secret management is now handled entirely by the SRM chart:
-  - to-default-storage-secret.yaml creates the secret when no existingSecret is set.
-  - _secrets.tpl exposes minio.ref.secretName for consumers.
-  - The official chart is pointed at that secret via minio.existingSecret.
+Secret wiring for the official MinIO chart (charts.min.io).
+
+The official MinIO chart reads credentials from the secret named by
+minio.existingSecret.  When existingSecret is set to a non-empty value the
+chart skips creating its own secret (which would contain default minioadmin
+credentials).
+
+The SRM chart sets minio.existingSecret to the auto-generated secret name
+(see values-to.yaml) so that:
+  1. MinIO skips its own secret creation.
+  2. to-default-storage-secret.yaml creates the secret with both
+     rootUser/rootPassword (for MinIO) and access-key/secret-key (for the
+     tool service), ensuring both consumers share the same credentials.
+
+No template overrides are required here; the wiring is done entirely through
+the minio.existingSecret value.
 */}}

--- a/chart/templates/_subchart.tpl
+++ b/chart/templates/_subchart.tpl
@@ -1,35 +1,11 @@
-{{- define "common.errors.insecureImages" -}}
-{{/* Ignore the insecure images check. */}}
-{{- end -}}
-
 {{/*
-Return false to block the subchart from creating a secret object (overwrites template).
-*/}}
-{{- define "minio.createSecret" -}}
-{{/* Block the MinIO chart from creating its own K8s Secret resource. */}}
-{{- false -}}
-{{- end -}}
+Official MinIO chart (charts.min.io) does not use Bitnami's common library,
+so the Bitnami template-override helpers (minio.createSecret,
+minio.secret.userValue, minio.secret.passwordValue, common.errors.insecureImages)
+are no longer needed and have been removed.
 
-{{/*
-Get the user to use to access MinIO&reg; (overwrites template).
+Secret management is now handled entirely by the SRM chart:
+  - to-default-storage-secret.yaml creates the secret when no existingSecret is set.
+  - _secrets.tpl exposes minio.ref.secretName for consumers.
+  - The official chart is pointed at that secret via minio.existingSecret.
 */}}
-{{- define "minio.secret.userValue" -}}
-{{- if (and (empty .Values.auth.rootUser) .Values.auth.forcePassword) }}
-    {{ required "A root username is required!" .Values.auth.rootUser }}
-{{- else -}}
-    {{/* Ignore password management, which is handled in _secrets.tpl. */}}
-    {{/* {{- include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "root-user" "providedValues" (list "auth.rootUser") "context" $) -}} */}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Get the password to use to access MinIO&reg; (overwrites template).
-*/}}
-{{- define "minio.secret.passwordValue" -}}
-{{- if (and (empty .Values.auth.rootPassword) .Values.auth.forcePassword) }}
-    {{ required "A root password is required!" .Values.auth.rootPassword }}
-{{- else -}}
-    {{/* Ignore password management, which is handled in _secrets.tpl. */}}
-    {{/* {{- include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "root-password" "providedValues" (list "auth.rootPassword") "context" $) -}} */}}
-{{- end -}}
-{{- end -}}

--- a/chart/templates/_to.tpl
+++ b/chart/templates/_to.tpl
@@ -91,8 +91,8 @@ Create the name of the TO workflow service account to use
 {{- end }}
 
 {{- define "srm-to.storageEndpoint" -}}
-{{- if .Values.minio.enabled -}}
-{{- print (include "minio.ref.fullname" .) "." .Release.Namespace ".svc.cluster.local:" .Values.minio.service.ports.api -}}
+{{- if .Values.features.minio -}}
+{{- print (include "minio.ref.fullname" .) "." .Release.Namespace ".svc.cluster.local:" .Values.minio.service.port -}}
 {{- else -}}
 {{- .Values.to.workflowStorage.endpoint -}}
 {{- end -}}
@@ -100,7 +100,7 @@ Create the name of the TO workflow service account to use
 
 {{- define "srm-to.storageTlsEnabled" -}}
 {{- $enabled := 0 -}}
-{{- if (or .Values.to.workflowStorage.endpointSecure (and .Values.minio.enabled .Values.minio.tls.existingSecret)) -}}
+{{- if (or .Values.to.workflowStorage.endpointSecure (and .Values.features.minio .Values.minio.tls.certSecret)) -}}
 {{- $enabled = 1 -}}
 {{- end -}}
 {{ $enabled }}
@@ -224,6 +224,12 @@ Duplicates of a Minio template helper so we can reference Minio's service name
 {{- end -}}
 
 {{/*
+NOTE: The Bitnami minio.claimName override (which appended "-snsd") has been
+removed. The official MinIO chart (charts.min.io) manages its own PVC naming
+internally and does not rely on this helper.
+*/}}
+
+{{/*
 Duplicates of an Argo template helper so we can reference the Argo controller's service name
 */}}
 
@@ -251,16 +257,5 @@ Duplicates of an Argo template helper so we can reference the Argo controller's 
     {{ default (include "argo-workflows.ref.controller.fullname" .) $serviceAccount.name }}
 {{- else -}}
     {{ default "default" $serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the PVC name, potentially forcing a switch to the single-node, single-drive configuration (overwrites template).
-*/}}
-{{- define "minio.claimName" -}}
-{{- if and .Values.persistence.existingClaim }}
-    {{- printf "%s" (tpl .Values.persistence.existingClaim $) -}}
-{{- else -}}
-    {{- printf "%s-snsd" (include "common.names.fullname" .) -}}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/cert-manager-tls-minio.yaml
+++ b/chart/templates/cert-manager-tls-minio.yaml
@@ -2,11 +2,11 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.minio.tls.existingSecret }}
+  name: {{ .Values.minio.tls.certSecret }}
 spec:
   isCA: false
   commonName: {{ include "minio.ref.fullname" . }}
-  secretName: {{ .Values.minio.tls.existingSecret }}
+  secretName: {{ .Values.minio.tls.certSecret }}
   duration: {{ .Values.tls.certManager.duration | quote }}
   renewBefore: {{ .Values.tls.certManager.renewBefore | quote }}
   privateKey:

--- a/chart/templates/to-default-storage-secret.yaml
+++ b/chart/templates/to-default-storage-secret.yaml
@@ -1,12 +1,15 @@
 {{- if .Values.features.minio -}}
-{{- if (not .Values.minio.existingSecret) -}}
-{{- $default := lookup "v1" "Secret" .Release.Namespace (include "srm-to.default.minio.secret" .) -}}
+{{- $generatedName := include "srm-to.default.minio.secret" . -}}
+{{- $existingSecret := .Values.minio.existingSecret | default "" -}}
+{{- $useGenerated := or (not $existingSecret) (eq $existingSecret $generatedName) -}}
+{{- if $useGenerated -}}
+{{- $default := lookup "v1" "Secret" .Release.Namespace $generatedName -}}
 {{- $accessKey := dig "data" "access-key" (randAlphaNum 10 | b64enc) $default | b64dec -}}
 {{- $secretKey := dig "data" "secret-key" (randAlphaNum 10 | b64enc) $default | b64dec -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "srm-to.default.minio.secret" . | quote }}
+  name: {{ $generatedName | quote }}
   labels:
     {{- include "srm-to.labels" . | nindent 4 }}
 type: Opaque

--- a/chart/templates/to-default-storage-secret.yaml
+++ b/chart/templates/to-default-storage-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.features.minio -}}
-{{- if (not .Values.minio.global.minio.existingSecret) -}}
+{{- if (not .Values.minio.existingSecret) -}}
 {{- $default := lookup "v1" "Secret" .Release.Namespace (include "srm-to.default.minio.secret" .) -}}
 {{- $accessKey := dig "data" "access-key" (randAlphaNum 10 | b64enc) $default | b64dec -}}
 {{- $secretKey := dig "data" "secret-key" (randAlphaNum 10 | b64enc) $default | b64dec -}}
@@ -12,7 +12,11 @@ metadata:
 type: Opaque
 data:
   # lookup requires cluster access, so a disconnected context (e.g., dry-run, template) has no password reuse with generated password(s)
+  # Keys used by the SRM tool service (legacy names kept for backward compatibility)
   access-key: {{ $accessKey | b64enc }}
   secret-key: {{ $secretKey | b64enc }}
+  # Keys expected by the official MinIO chart (charts.min.io) when existingSecret is set
+  rootUser: {{ $accessKey | b64enc }}
+  rootPassword: {{ $secretKey | b64enc }}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/to-networkpolicy.yaml
+++ b/chart/templates/to-networkpolicy.yaml
@@ -30,8 +30,7 @@ spec:
     to:
     - podSelector:
         matchLabels:
-          app.kubernetes.io/name: {{ include "minio.ref.name" . }}
-          app.kubernetes.io/instance: {{ .Release.Name | quote }}
+          app: {{ include "minio.ref.name" . }}
   ingress:
   - ports:
     - port: 3333
@@ -83,8 +82,7 @@ spec:
       port: 9000
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "minio.ref.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      app: {{ include "minio.ref.name" . }}
   policyTypes:
   - Ingress
   - Egress

--- a/chart/values/values-tls.yaml
+++ b/chart/values/values-tls.yaml
@@ -86,7 +86,8 @@ minio:
     # @ignore (refer to values-to.yaml file for details)
     enabled: true
     # @ignore (refer to values-to.yaml file for details)
-    existingSecret: srm-minio-tls-secret
+    # Official MinIO chart uses tls.certSecret (not tls.existingSecret)
+    certSecret: srm-minio-tls-secret
 
 to:
   # @ignore (refer to values-to.yaml file for details)

--- a/chart/values/values-to.yaml
+++ b/chart/values/values-to.yaml
@@ -303,9 +303,19 @@ minio:
     capabilities:
       drop:
         - ALL
-    readOnlyRootFilesystem: false   # MinIO writes to /tmp internally
+    readOnlyRootFilesystem: true
     seccompProfile:
       type: RuntimeDefault
+
+  # -- extra volumes to add to the MinIO pod.
+  extraVolumes:
+    - name: tmp-dir
+      emptyDir: {}
+
+  # -- extra volume mounts to add to the MinIO container
+  extraVolumeMounts:
+    - name: tmp-dir
+      mountPath: /tmp
 
   # -- MinIO TLS configuration
   tls:

--- a/chart/values/values-to.yaml
+++ b/chart/values/values-to.yaml
@@ -257,7 +257,11 @@ minio:
       # -- the required memory for the MinIO workload
       memory: 5120Mi
 
-  # -- the MinIO deployment mode; must be "standalone" for single-node single-drive deployments
+  # -- the MinIO deployment mode.
+  # Use "standalone" for single-node single-drive deployments (replicas=1, drivesPerNode=1).
+  # Use "distributed" for multi-node/multi-drive deployments (replicas>1); in that case also
+  # increase replicas, drivesPerNode, and pools accordingly and ensure a ReadWriteMany-capable
+  # StorageClass is available.  The official chart defaults to "distributed".
   mode: standalone
   # -- the number of MinIO drives per node (single-node single-drive mode)
   drivesPerNode: 1
@@ -322,8 +326,8 @@ minio:
   serviceAccount:
     # -- whether to create a service account for MinIO
     create: true
-    # -- the name of the service account; auto-generated when unset
-    name: ""
+    # -- the name of the service account.
+    name: "minio"
 
   # -- MinIO environment variables (official chart uses 'environment' map)
   environment:

--- a/chart/values/values-to.yaml
+++ b/chart/values/values-to.yaml
@@ -187,71 +187,166 @@ to:
     configMapPublicCertKeyName: ""
 
 minio:
-  # -- whether to enable the on-cluster MinIO component
-  enabled: true
-  auth:
-    # -- whether to mount MinIO credential values as files
-    useCredentialsFiles: true
-  extraEnvVars:
-  # -- skip the MinIO client configuration, which may not work when TLS is enabled
-  - name: MINIO_SKIP_CLIENT
-    value: "yes"
-  global:
-    minio:
-      # -- the K8s secret name with the MinIO access and secret key with required fields access-key and secret-key
-      # Command:
-      # kubectl -n srm create secret generic minio-secret --from-literal=access-key=admin --from-literal=secret-key=password
-      existingSecret:
-    security:
-      # -- true to avoid error when using a MinIO with a private container image registry
-      allowInsecureImages: true
+  # ---------------------------------------------------------------------------
+  # Official MinIO Helm chart (https://charts.min.io/) — replaces the legacy
+  # Bitnami-based chart previously hosted at https://codedx.github.io/srm-k8s.
+  # ---------------------------------------------------------------------------
+
+  # -- the K8s secret name containing MinIO credentials with required fields
+  # rootUser and rootPassword (used by the official chart) AND access-key /
+  # secret-key (used by the SRM tool service).  When unset, the SRM chart
+  # auto-generates a secret named <release>-minio-default-secret that contains
+  # all four keys.
+  # Command (bring-your-own secret):
+  # kubectl -n srm create secret generic minio-secret \
+  #   --from-literal=rootUser=admin \
+  #   --from-literal=rootPassword=password \
+  #   --from-literal=access-key=admin \
+  #   --from-literal=secret-key=password
+  existingSecret: ""
+
+  # -- the Docker image to use for the MinIO workload
   image:
-    # -- the registry name and optional registry suffix for the MinIO Docker image
-    registry: docker.io
-    # -- the Docker image repository name for the MinIO workload
-    repository: bitnamilegacy/minio
-    # -- the Docker image version for the MinIO workload
-    tag: 2025.7.23-debian-12-r5
+    # -- the Docker image repository for MinIO
+    repository: quay.io/minio/minio
+    # -- the Docker image tag for MinIO
+    tag: RELEASE.2025-04-22T22-12-26Z
     # -- the K8s Docker image pull policy for the MinIO workload
-    pullSecrets: []
-    #  - private-registry
+    pullPolicy: IfNotPresent
+
+  # -- the K8s image pull secrets to use for MinIO Docker images
+  imagePullSecrets: []
+  #  - name: private-registry
+
   # -- the node selector to use for the MinIO workload
   nodeSelector: {}
+
   # -- the pod annotations to use for the MinIO pod
   podAnnotations: {}
+
   # -- labels added to the MinIO pod
   podLabels: {}
-  persistence:
-    # -- the size of the MinIO persistent volume 
-    size: 64Gi
-    # -- the existing claim to use for the MinIO persistent volume; a new persistent volume is generated when unset
-    existingClaim:
-    # -- the storage class name for the MinIO persistent volume; the default storage class used when unset
-    storageClass:
-  podDisruptionBudget:
-    # -- whether to create a pod disruption budget for the MinIO component
-    enabled: true
-    # -- the maximum number of unavailable instances of the MinIO component
-    maxUnavailable: 0
-  podSecurityContext:
-    # -- whether to run the MinIO pod as a non-root user
-    runAsNonRoot: true
-  # -- the MinIO component priority value, which must be set relative to other Tool Orchestration component priority values
+
+  # -- the pod tolerations for the MinIO component
+  tolerations: []
+
+  # -- the MinIO component priority class name
+  priorityClassName: ""
+
+  # -- the MinIO component priority value (used when creating a PriorityClass)
   priorityClassValue: 10100
+
+  # -- resource limits and requests for the MinIO workload
   resources:
+    requests:
+      memory: 1Gi
+      cpu: 250m
     limits:
       # -- the required CPU for the MinIO workload
       cpu: 2000m
       # -- the required memory for the MinIO workload
       memory: 5120Mi
-  # -- the K8s secret name for web component TLS with required fields tls.crt and tls.key
+
+  # -- the number of MinIO drives per node (single-node single-drive mode)
+  drivesPerNode: 1
+  # -- the number of MinIO replicas (1 = standalone mode)
+  replicas: 1
+  # -- the number of MinIO pools
+  pools: 1
+
+  persistence:
+    # -- whether to enable persistent storage for MinIO
+    enabled: true
+    # -- the size of the MinIO persistent volume
+    size: 64Gi
+    # -- the existing claim to use for the MinIO persistent volume; a new PVC is created when unset
+    existingClaim: ""
+    # -- the storage class name for the MinIO persistent volume; the default storage class is used when unset
+    storageClass: ""
+
+  # -- the MinIO service configuration
+  service:
+    # -- the K8s service type for MinIO
+    type: ClusterIP
+    # -- the MinIO API port
+    port: 9000
+    # -- the MinIO console port
+    consolePort: 9001
+
+  # -- MinIO pod security context (non-root, matching SRM security posture)
+  securityContext:
+    enabled: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    runAsNonRoot: true
+
+  # -- MinIO container security context
+  containerSecurityContext:
+    enabled: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false   # MinIO writes to /tmp internally
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- MinIO TLS configuration
   tls:
-    # -- whether to enable MinIO TLS
+    # -- whether to enable TLS for MinIO
     enabled: false
-    # -- name of K8s secret resource with required fields tls.crt, tls.key, and ca.crt
-    existingSecret:
-  # -- the pod tolerations for the MinIO component
-  tolerations: []
+    # -- the name of the K8s Secret containing TLS cert/key/ca (fields: tls.crt, tls.key, ca.crt)
+    # Created automatically by cert-manager when tls.certManager.enabled=true in the parent chart.
+    certSecret: ""
+
+  # -- MinIO pod disruption budget
+  podDisruptionBudget:
+    # -- whether to create a pod disruption budget for the MinIO component
+    enabled: true
+    # -- the maximum number of unavailable MinIO instances
+    maxUnavailable: 0
+
+  # -- MinIO service account
+  serviceAccount:
+    # -- whether to create a service account for MinIO
+    create: true
+    # -- the name of the service account; auto-generated when unset
+    name: ""
+
+  # -- MinIO environment variables (official chart uses 'environment' map)
+  environment:
+    # Disable the MinIO browser console in production (access via kubectl port-forward if needed)
+    MINIO_BROWSER: "off"
+
+  # -- MinIO bucket to pre-create on startup (matches SRM tool orchestration default)
+  buckets:
+    - name: code-dx-storage
+      policy: none
+      purge: false
+
+  # -- MinIO users to pre-create (leave empty; credentials come from existingSecret / auto-generated secret)
+  users: []
+
+  # -- MinIO policies to pre-create
+  policies: []
+
+  # -- MinIO liveness probe
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+
+  # -- MinIO readiness probe
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 10
+    failureThreshold: 3
 
 argo-workflows:
   # depends on https://github.com/codedx/codedx-kubernetes/tree/master/setup/core/crds/v1

--- a/chart/values/values-to.yaml
+++ b/chart/values/values-to.yaml
@@ -193,17 +193,27 @@ minio:
   # ---------------------------------------------------------------------------
 
   # -- the K8s secret name containing MinIO credentials with required fields
-  # rootUser and rootPassword (used by the official chart) AND access-key /
-  # secret-key (used by the SRM tool service).  When unset, the SRM chart
-  # auto-generates a secret named <release>-minio-default-secret that contains
-  # all four keys.
-  # Command (bring-your-own secret):
+  # rootUser and rootPassword (used by the official MinIO chart) AND access-key /
+  # secret-key (used by the SRM tool service).
+  #
+  # IMPORTANT: this field MUST be set to a non-empty value so that the official
+  # MinIO chart skips creating its own secret (which would contain default
+  # minioadmin credentials).  The SRM chart creates the secret named here via
+  # to-default-storage-secret.yaml when the value equals the auto-generated name
+  # (<release>-minio-default-secret) or is empty.
+  #
+  # Default: "srm-minio-default-secret" (matches release name "srm").
+  # Override with --set minio.existingSecret=<release>-minio-default-secret
+  # if your Helm release name differs from "srm".
+  #
+  # To bring your own secret, pre-create it with all four keys and set this
+  # field to its name:
   # kubectl -n srm create secret generic minio-secret \
   #   --from-literal=rootUser=admin \
   #   --from-literal=rootPassword=password \
   #   --from-literal=access-key=admin \
   #   --from-literal=secret-key=password
-  existingSecret: ""
+  existingSecret: "srm-minio-default-secret"
 
   # -- the Docker image to use for the MinIO workload
   image:
@@ -247,6 +257,8 @@ minio:
       # -- the required memory for the MinIO workload
       memory: 5120Mi
 
+  # -- the MinIO deployment mode; must be "standalone" for single-node single-drive deployments
+  mode: standalone
   # -- the number of MinIO drives per node (single-node single-drive mode)
   drivesPerNode: 1
   # -- the number of MinIO replicas (1 = standalone mode)
@@ -275,7 +287,6 @@ minio:
 
   # -- MinIO pod security context (non-root, matching SRM security posture)
   securityContext:
-    enabled: true
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
@@ -283,7 +294,6 @@ minio:
 
   # -- MinIO container security context
   containerSecurityContext:
-    enabled: true
     runAsNonRoot: true
     allowPrivilegeEscalation: false
     capabilities:

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -68,7 +68,7 @@
     + [Scanner Nodes Pre-work](#scanner-nodes-pre-work)
     + [Bitnami PostgreSQL Chart Pre-work](#bitnami-postgresql-chart-pre-work)
     + [Bitnami Redis Chart Pre-work](#bitnami-redis-chart-pre-work)
-    + [Bitnami MinIO Chart Pre-work](#bitnami-minio-chart-pre-work)
+    + [Official MinIO Chart Pre-work](#official-minio-chart-pre-work)
 - [Tool Orchestration Pre-work](#tool-orchestration-pre-work)
   * [Node Pool Pre-work](#node-pool-pre-work)
   * [Object Storage Pre-work](#object-storage-pre-work)
@@ -1338,48 +1338,65 @@ helm -n srm upgrade --create-namespace --install --repo https://charts.bitnami.c
 
 Set the redis.tls Helm chart configuration based on whether you plan to enable TLS for your Redis instance. You can find the Redis TLS certificate in its pod at /opt/bitnami/redis/certs/tls.crt.
 
-### Bitnami MinIO Chart Pre-work
+### Official MinIO Chart Pre-work
 
-The MinIO software is licensed under the [GNU Affero General Public License v3.0](https://github.com/minio/minio/blob/master/LICENSE) or a commercial enterprise license. The Bitnami MinIO Helm chart license is available [here](https://github.com/bitnami/charts/tree/main/bitnami/minio#license).
+The MinIO software is licensed under the [GNU Affero General Public License v3.0](https://github.com/minio/minio/blob/master/LICENSE) or a commercial enterprise license. The official MinIO Helm chart is available at [https://charts.min.io/](https://charts.min.io/).
 
-The following is an example of the MinIO chart parameters for version 17.0.16 that customizes MinIO to meet Scan Farm requirements (refer to the requirements section to identify the storage size suitable for your environment):
+> **Migration note:** The SRM chart previously bundled a forked Bitnami MinIO chart (`https://codedx.github.io/srm-k8s`, version 3.5.0). As of this release the dependency has been replaced with the official MinIO Helm chart (`https://charts.min.io/`, version 5.4.0). See the [MinIO Migration Plan](#minio-migration-plan) section for step-by-step upgrade instructions.
 
-```
-defaultInitContainers:
-  volumePermissions:
-    image:
-      repository: bitnamilegacy/os-shell
+The following is an example of the MinIO chart parameters that customizes MinIO to meet Scan Farm requirements (refer to the requirements section to identify the storage size suitable for your environment):
+
+```yaml
 image:
-  repository: bitnamilegacy/minio
-provisioning:
-  enabled: true
-  buckets:
-  - name:  "storage"
-    region: us-east-1
-  - name: "cache"
-    region: us-east-1
-    lifecycle:
-    - id: cache
-      disabled: false
-      expiry:
-        days: 8
+  repository: quay.io/minio/minio
+  tag: RELEASE.2025-04-22T22-12-26Z
+
+buckets:
+  - name: storage
+    policy: none
+    purge: false
+  - name: cache
+    policy: none
+    purge: false
+
 persistence:
   size: 100Gi
+
+securityContext:
+  enabled: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  runAsNonRoot: true
+
+containerSecurityContext:
+  enabled: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 ```
 
-If you store the above YAML in a file named minio.yaml, you can run helm like this:
+If you store the above YAML in a file named `minio.yaml`, you can install the official MinIO chart like this:
 
+```bash
+helm -n srm upgrade --create-namespace --install \
+  --repo https://charts.min.io/ \
+  --version 5.4.0 \
+  minio minio \
+  -f minio.yaml \
+  --set rootUser=<username> \
+  --set rootPassword=<password>
 ```
-helm -n srm upgrade --create-namespace --install --repo https://charts.bitnami.com/bitnami --version 11.10.24 minio minio -f minio.yaml
-```
 
->Note: The chart notes explain how to obtain the initial password.
-
-Set MinIO's root username and password using the minio.auth.rootUser and minio.auth.rootPassword Helm chart parameters. You can define default buckets for the Storage Service and Cache Service using the minio.defaultBuckets chart parameter, or you can create them by hand after installing MinIO.  
+Set MinIO's root username and password using the `rootUser` and `rootPassword` Helm chart parameters (or via an `existingSecret` — see below). You can define default buckets for the Storage Service and Cache Service using the `buckets` chart parameter, or you can create them by hand after installing MinIO.
 
 You must configure a lifecycle policy on the cache bucket. If you did not configure the policy during deployment, you can use the following command with an "srm" mc alias you can define using the MinIO endpoint and root credential, replacing the cache-bucket name and day count (must be greater than, not equal to, 7) as necessary:
 
-```
+```bash
 $ mc alias set srm <MinIO endpoint> <MinIO root username> <MinIO root password>
 $ mc ilm add --expiry-days 8 srm/cache-bucket
 ```
@@ -1392,7 +1409,7 @@ Alternatively, you can proxy MinIO by using the same hostname for both Software 
 
 The following two examples show Ingress and Route examples that use hostname `srm.local` to make a `minio` Kubernetes service available at http://srm.local/upload/. Note the use of the rewrite-related annotations in both examples to drop "/upload/" when routing a request to the MinIO service.
 
-```
+```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -1417,7 +1434,7 @@ spec:
         pathType: ImplementationSpecific
 ```
 
-```
+```yaml
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -1443,6 +1460,176 @@ spec:
 ```
 
 Note your external MinIO URL and your in-cluster URL if you plan to specify that optimization in the Helm Prep Wizard.
+
+---
+
+## MinIO Migration Plan
+
+This section describes how to migrate an existing SRM deployment from the legacy Bitnami-based MinIO chart to the official MinIO Helm chart with minimal downtime.
+
+### Overview of Changes
+
+| Aspect | Legacy (Bitnami fork) | Official (charts.min.io) |
+|---|---|---|
+| Chart repository | `https://codedx.github.io/srm-k8s` | `https://charts.min.io/` |
+| Chart version | 3.5.0 | 5.4.0 |
+| Docker image | `docker.io/bitnamilegacy/minio` | `quay.io/minio/minio` |
+| Secret keys | `access-key` / `secret-key` | `rootUser` / `rootPassword` |
+| `existingSecret` path | `minio.global.minio.existingSecret` | `minio.existingSecret` |
+| TLS secret param | `minio.tls.existingSecret` | `minio.tls.certSecret` |
+| Pod label selector | `app.kubernetes.io/name: minio` | `app: minio` |
+| Service port value path | `minio.service.ports.api` | `minio.service.port` |
+| PVC name suffix | `<release>-minio-snsd` | `<release>-minio` |
+
+### Pre-Migration Checklist
+
+- [ ] Confirm `features.minio: true` and `features.to: true` in your current values
+- [ ] Record the current MinIO PVC name: `kubectl -n srm get pvc | grep minio`
+- [ ] Record the current MinIO credentials (access-key / secret-key) from the existing secret
+- [ ] Verify the bucket name in use (default: `code-dx-storage`)
+- [ ] Ensure you have a recent backup of the MinIO PVC data
+- [ ] Confirm FluxCD / GitOps reconciliation is paused or you are performing a manual `helm upgrade`
+
+### Step-by-Step Migration
+
+#### Step 1 — Retain the existing PVC
+
+Before upgrading, prevent Kubernetes from deleting the existing MinIO PVC when the old Deployment is removed:
+
+```bash
+# Find the PVC name (typically <release>-minio-snsd)
+kubectl -n srm get pvc | grep minio
+
+# Switch reclaim policy to Retain so data survives pod/PVC deletion
+kubectl -n srm patch pv <PV_NAME> \
+  -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+```
+
+#### Step 2 — Scale down Tool Orchestration workloads
+
+```bash
+kubectl -n srm scale --replicas=0 deployment/srm-to
+kubectl -n srm scale --replicas=0 deployment/srm-minio
+```
+
+#### Step 3 — Prepare the new credentials secret
+
+The official MinIO chart expects `rootUser` and `rootPassword` keys. The SRM chart also needs `access-key` and `secret-key` for the tool service. Create a single secret with all four keys:
+
+```bash
+# Replace <access-key> and <secret-key> with your existing credentials
+kubectl -n srm create secret generic minio-secret \
+  --from-literal=rootUser=<access-key> \
+  --from-literal=rootPassword=<secret-key> \
+  --from-literal=access-key=<access-key> \
+  --from-literal=secret-key=<secret-key>
+```
+
+Then set `minio.existingSecret: minio-secret` in your values file.
+
+#### Step 4 — Update your Helm values
+
+Replace the legacy `minio:` block in your `values-to.yaml` (or override file) with the new official chart values. Key changes:
+
+```yaml
+# BEFORE (legacy Bitnami)
+minio:
+  enabled: true
+  auth:
+    useCredentialsFiles: true
+  global:
+    minio:
+      existingSecret: minio-secret   # <-- old path
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/minio
+    tag: 2025.7.23-debian-12-r5
+  tls:
+    existingSecret: srm-minio-tls-secret  # <-- old TLS param
+
+# AFTER (official MinIO chart)
+minio:
+  existingSecret: minio-secret            # <-- new path (top-level)
+  image:
+    repository: quay.io/minio/minio
+    tag: RELEASE.2025-04-22T22-12-26Z
+  tls:
+    certSecret: srm-minio-tls-secret      # <-- new TLS param
+  persistence:
+    existingClaim: <old-pvc-name>         # <-- reuse existing PVC
+```
+
+#### Step 5 — Run helm dependency update
+
+```bash
+cd chart/
+helm dependency update .
+```
+
+This fetches the new `minio-5.4.0.tgz` from `https://charts.min.io/` and removes the old Bitnami chart from the `charts/` directory.
+
+#### Step 6 — Upgrade the SRM Helm release
+
+```bash
+helm -n srm upgrade srm . \
+  -f values/values-to.yaml \
+  -f values/values-tls.yaml \   # if using TLS
+  --set minio.existingSecret=minio-secret \
+  --atomic \
+  --timeout 10m
+```
+
+#### Step 7 — Validate
+
+```bash
+# Confirm the MinIO pod is Running
+kubectl -n srm get pods | grep minio
+
+# Confirm the bucket exists and data is intact
+kubectl -n srm exec -it deploy/srm-minio -- \
+  mc alias set local http://localhost:9000 <access-key> <secret-key>
+kubectl -n srm exec -it deploy/srm-minio -- \
+  mc ls local/code-dx-storage
+
+# Scale Tool Orchestration back up
+kubectl -n srm scale --replicas=1 deployment/srm-to
+kubectl -n srm scale --replicas=1 deployment/srm-minio
+```
+
+#### Step 8 — Smoke test
+
+Run a test orchestrated analysis in SRM and confirm it completes successfully.
+
+### Rollback Strategy
+
+If the upgrade fails or validation does not pass:
+
+```bash
+# Roll back the Helm release to the previous revision
+helm -n srm rollback srm
+
+# If the new PVC was created and the old PVC still exists (Retain policy),
+# patch the old PV back to the release and delete the new PVC:
+kubectl -n srm delete pvc <new-minio-pvc>
+kubectl -n srm patch pv <old-PV_NAME> \
+  -p '{"spec":{"claimRef":null}}'
+# Then re-create the old PVC pointing at the retained PV and re-run helm upgrade
+```
+
+### Risks and Validation Checklist
+
+| Risk | Mitigation |
+|---|---|
+| PVC data loss during chart swap | Set PV reclaim policy to `Retain` before upgrade (Step 1) |
+| Credential mismatch (old `access-key` vs new `rootUser`) | Create unified secret with all four keys (Step 3) |
+| NetworkPolicy pod-selector mismatch | Updated from `app.kubernetes.io/name` to `app` label in `to-networkpolicy.yaml` |
+| Tool service cannot reach MinIO | Verify `minio.service.port: 9000` and DNS `<release>-minio.<ns>.svc.cluster.local` |
+| TLS cert secret field name change | Updated from `tls.existingSecret` to `tls.certSecret` in values and cert-manager template |
+| FluxCD reconciliation loop | Pause FluxCD `HelmRelease` before upgrade; resume after validation |
+| Image pull failure (private registry) | Update `minio.imagePullSecrets` with your registry pull secret |
+| Bucket not found after migration | Confirm `minio.buckets[0].name: code-dx-storage` in new values |
+
+---
 
 # Tool Orchestration Pre-work
 
@@ -4272,7 +4459,7 @@ Depending on the Software Risk Manager features you install and how you configur
 |:-|:-|:-|:-|
 | argo-workflows | Tool Orchestration | https://argoproj.github.io/argo-helm | Required to manage orchestrated analyses |
 | mariadb | Core | https://codedx.github.io/srm-k8s | Optional on-cluster Software Risk Manager database |
-| minio | Tool Orchestration | https://codedx.github.io/srm-k8s | Optional on-cluster Software Risk Manager workflow storage |
+| minio | Tool Orchestration | https://charts.min.io/ | Optional on-cluster Software Risk Manager workflow storage |
 | scan-services | Scan Farm | https://repo.blackduck.com/artifactory/sig-cloudnative | Required to run SAST and SCA scans |
 
 ## Values
@@ -4353,26 +4540,35 @@ The following table lists the Software Risk Manager Helm chart values. Run `helm
 | mariadb.slave.resources.limits.cpu | string | `"1000m"` | the required CPU for the MariaDB replica database workload |
 | mariadb.slave.resources.limits.memory | string | `"8192Mi"` | the required memory for the MariaDB replica database workload |
 | mariadb.slave.tolerations | list | `[]` | the pod tolerations for the MariaDB replica database component |
-| minio.enabled | bool | `true` | whether to enable the on-cluster MinIO component |
-| minio.auth.useCredentialsFiles | bool | `true` | whether to mount MinIO credential values as files |
-| minio.global.minio.existingSecret | string | `nil` | the K8s secret name with the MinIO access and secret key with required fields access-key and secret-key Command: kubectl -n srm create secret generic minio-secret --from-literal=access-key=admin --from-literal=secret-key=password |
-| minio.image.pullSecrets | list | `[]` | the K8s Docker image pull policy for the MinIO workload |
-| minio.image.registry | string | `"docker.io"` | the registry name and optional registry suffix for the MinIO Docker image |
-| minio.image.repository | string | `"bitnamilegacy/minio"` | the Docker image repository name for the MinIO workload |
-| minio.image.tag | string | `"2025.7.23-debian-12-r5"` | the Docker image version for the MinIO workload |
+| minio.existingSecret | string | `""` | the K8s secret name with MinIO credentials; required fields: rootUser, rootPassword (official chart), access-key, secret-key (SRM tool service). Auto-generated when unset. Command: kubectl -n srm create secret generic minio-secret --from-literal=rootUser=admin --from-literal=rootPassword=password --from-literal=access-key=admin --from-literal=secret-key=password |
+| minio.image.repository | string | `"quay.io/minio/minio"` | the Docker image repository name for the MinIO workload |
+| minio.image.tag | string | `"RELEASE.2025-04-22T22-12-26Z"` | the Docker image tag for the MinIO workload |
+| minio.image.pullPolicy | string | `"IfNotPresent"` | the K8s Docker image pull policy for the MinIO workload |
+| minio.imagePullSecrets | list | `[]` | the K8s image pull secrets to use for MinIO Docker images |
 | minio.nodeSelector | object | `{}` | the node selector to use for the MinIO workload |
-| minio.persistence.existingClaim | string | `nil` | the existing claim to use for the MinIO persistent volume; a new persistent volume is generated when unset |
-| minio.persistence.size | string | `"64Gi"` | the size of the MinIO persistent volume  |
-| minio.persistence.storageClass | string | `nil` | the storage class name for the MinIO persistent volume; the default storage class used when unset |
+| minio.persistence.enabled | bool | `true` | whether to enable persistent storage for MinIO |
+| minio.persistence.existingClaim | string | `""` | the existing claim to use for the MinIO persistent volume; a new PVC is created when unset |
+| minio.persistence.size | string | `"64Gi"` | the size of the MinIO persistent volume |
+| minio.persistence.storageClass | string | `""` | the storage class name for the MinIO persistent volume; the default storage class is used when unset |
 | minio.podAnnotations | object | `{}` | the pod annotations to use for the MinIO pod |
 | minio.podDisruptionBudget.enabled | bool | `true` | whether to create a pod disruption budget for the MinIO component |
 | minio.podDisruptionBudget.maxUnavailable | int | `0` | the maximum number of unavailable instances of the MinIO component |
 | minio.podLabels | object | `{}` | labels added to the MinIO pod |
 | minio.priorityClassValue | int | `10100` | the MinIO component priority value, which must be set relative to other Tool Orchestration component priority values |
+| minio.replicas | int | `1` | the number of MinIO replicas (1 = standalone/single-node mode) |
+| minio.resources.requests.cpu | string | `"250m"` | the CPU request for the MinIO workload |
+| minio.resources.requests.memory | string | `"1Gi"` | the memory request for the MinIO workload |
 | minio.resources.limits.cpu | string | `"2000m"` | the required CPU for the MinIO workload |
-| minio.resources.limits.memory | string | `"500Mi"` | the required memory for the MinIO workload |
-| minio.tls.enabled | boolean | `false` | whether to use TLS for MinIO |
-| minio.tls.existingSecret | string | `nil` | the K8s secret name for MinIO component TLS with required fields tls.crt, tls.key, and ca.crt |
+| minio.resources.limits.memory | string | `"5120Mi"` | the required memory for the MinIO workload |
+| minio.securityContext.enabled | bool | `true` | whether to apply the pod security context for MinIO |
+| minio.securityContext.runAsUser | int | `1000` | the UID for the MinIO pod |
+| minio.securityContext.runAsGroup | int | `1000` | the GID for the MinIO pod |
+| minio.securityContext.fsGroup | int | `1000` | the fsGroup for the MinIO pod |
+| minio.securityContext.runAsNonRoot | bool | `true` | whether to run the MinIO pod as non-root |
+| minio.service.port | int | `9000` | the MinIO API service port |
+| minio.service.consolePort | int | `9001` | the MinIO console service port |
+| minio.tls.enabled | bool | `false` | whether to enable TLS for MinIO |
+| minio.tls.certSecret | string | `""` | the K8s Secret name containing TLS cert/key/ca (fields: tls.crt, tls.key, ca.crt); created by cert-manager when tls.certManager.enabled=true |
 | minio.tolerations | list | `[]` | the pod tolerations for the MinIO component |
 | networkPolicy.enabled | bool | `false` | whether to enable network policies for SRM components that support network policy |
 | networkPolicy.k8sApiPort | int | `443` | the port for the K8s API, required when using the Tool Orchestration feature |

--- a/ps/build/image.ps1
+++ b/ps/build/image.ps1
@@ -57,11 +57,17 @@ argo-workflows:
 "@ | Out-File (Get-ToDockerImageLocationValuesPath $config)
 
 		if (-not $config.skipMinIO) {
+			# The official MinIO chart (charts.min.io) uses a single image.repository
+			# field containing the full image reference; there is no separate registry field.
+			$minioRepo = if ($config.dockerRegistry -and $config.dockerRegistry -ne 'docker.io') {
+				"$($config.dockerRegistry)/$($repositoryPrefix)minio/minio"
+			} else {
+				"$($repositoryPrefix)quay.io/minio/minio"
+			}
 			@"
 minio:
-  image:
-    registry: '$($config.dockerRegistry)'
-    repository: '$("$($repositoryPrefix)bitnami/minio")'
+		image:
+		  repository: '$minioRepo'
 "@ | Out-File (Get-StorageDockerImageLocationValuesPath $config)
 		}
 	}

--- a/ps/build/to.ps1
+++ b/ps/build/to.ps1
@@ -122,9 +122,17 @@ to:
 	}
 }
 
+function Get-MinioDefaultSecretName($config) {
+	"$($config.releaseName)-minio-default-secret"
+}
+
 function New-InternalWorkflowStorage($config) {
 
 	if ($config.useGeneratedPwds) {
+		@"
+minio:
+  existingSecret: $(Get-MinioDefaultSecretName $config)
+"@ | Out-File (Get-ToWorkflowStoragePath $config)
 		return
 	}
 
@@ -134,7 +142,7 @@ function New-InternalWorkflowStorage($config) {
 	New-ToStorageSecret $config 'admin' $config.minioAdminPwd
 	@"
 minio:
-	 existingSecret: $(Get-ToStorageSecretName $config)
+  existingSecret: $(Get-ToStorageSecretName $config)
 "@ | Out-File (Get-ToWorkflowStoragePath $config)
 }
 

--- a/ps/build/to.ps1
+++ b/ps/build/to.ps1
@@ -44,9 +44,14 @@ web:
 
 function New-ToStorageSecret($config, $storageUsername, $storagePwd) {
 
+	# The secret must satisfy two consumers:
+	#   1. SRM tool service mounts access-key / secret-key
+	#   2. Official MinIO chart reads rootUser / rootPassword from existingSecret
 	New-GenericSecret $config.namespace (Get-ToStorageSecretName $config) -keyValues @{
 		"access-key"=$storageUsername
 		"secret-key"=$storagePwd
+		"rootUser"=$storageUsername
+		"rootPassword"=$storagePwd
 	} -dryRun | Out-File (Get-ToWorkflowStorageSecretK8sPath $config)
 }
 
@@ -129,9 +134,7 @@ function New-InternalWorkflowStorage($config) {
 	New-ToStorageSecret $config 'admin' $config.minioAdminPwd
 	@"
 minio:
-  global:
-    minio:
-      existingSecret: $(Get-ToStorageSecretName $config)
+	 existingSecret: $(Get-ToStorageSecretName $config)
 "@ | Out-File (Get-ToWorkflowStoragePath $config)
 }
 
@@ -146,9 +149,7 @@ function New-ToolOrchestrationConfig($config) {
 	$minioEnabled = $(ConvertTo-Json (-not $config.skipMinIO))
 	@"
 features:
-  minio: $minioEnabled
-minio:
-  enabled: $minioEnabled
+	 minio: $minioEnabled
 "@ | Out-File (Get-ToConfigMinIOValuesPath $config)
 
 	if ($config.toolServiceReplicas -gt 0) {

--- a/ps/steps/scanfarm-storage.ps1
+++ b/ps/steps/scanfarm-storage.ps1
@@ -812,7 +812,7 @@ available at https://srm.local/upload/ would mean specifying "upload" for
 your context path.
 
 Note: You can find an example NGINX Community ingress resource at this URL:
-https://github.com/codedx/srm-k8s/blob/main/docs/DeploymentGuide.md#bitnami-minio-chart-pre-work
+https://github.com/codedx/srm-k8s/blob/main/docs/DeploymentGuide.md#official-minio-chart-pre-work
 
 '@
 


### PR DESCRIPTION
Replaces the legacy Bitnami-based MinIO Helm dependency with the official MinIO chart (https://charts.min.io/, v5.4.0). The Bitnami fork was unmaintained and used a different image (bitnami/minio) and values schema. This migration aligns with the upstream MinIO project.

https://blackduck.atlassian.net/browse/CDX-4678
